### PR TITLE
fix: 상점에서 구매 가능 목록 보여주기 로직 수정

### DIFF
--- a/team6_TextGame/team6_TextGame/Characters/Player.cs
+++ b/team6_TextGame/team6_TextGame/Characters/Player.cs
@@ -54,6 +54,11 @@ namespace team6_TextGame.Characters
             inventory.Add(item);
         }
         */
+        public bool HasItem(Item item)
+        {
+            return equips.Any(equipItem => equipItem.id == item.id) ||
+                   consumes.Any(consumeItem => consumeItem.id == item.id);
+        }
 
         public void AddEquipsInven(Item item)
         {
@@ -88,7 +93,7 @@ namespace team6_TextGame.Characters
         {
             gold += amount;
         }
-        
+
         public void ReceiveExp(int amount)
         {
             if (level > expToLvUp.Count)

--- a/team6_TextGame/team6_TextGame/Program.cs
+++ b/team6_TextGame/team6_TextGame/Program.cs
@@ -29,7 +29,7 @@ class Program
         string name;
         Player character;
         //이름 입력
-        while(true)
+        while (true)
         {
             Console.Clear();
             Console.WriteLine("당신의 이름은 무엇입니까?");
@@ -39,7 +39,7 @@ class Program
             Console.WriteLine("2. 아닙니다.\n");
 
             var key = Console.ReadKey(true).Key;
-            if (key ==  ConsoleKey.D1 || key == ConsoleKey.NumPad1)
+            if (key == ConsoleKey.D1 || key == ConsoleKey.NumPad1)
             {
                 break;
             }
@@ -68,7 +68,7 @@ class Program
         bool isFirst = true;
         while (true)
         {
-            if(!isFirst)
+            if (!isFirst)
             {
                 Console.WriteLine("잘못된 입력입니다. 다시 입력해주세요.");
             }
@@ -77,19 +77,22 @@ class Program
 
             var key = Console.ReadKey(true).Key;
 
-            if(key == ConsoleKey.D1 || key == ConsoleKey.NumPad1)
+            if (key == ConsoleKey.D1 || key == ConsoleKey.NumPad1)
             {
                 character = new Warrior(name);
                 break;
-            } else if(key == ConsoleKey.D2 || key == ConsoleKey.NumPad2)
+            }
+            else if (key == ConsoleKey.D2 || key == ConsoleKey.NumPad2)
             {
                 character = new Archer(name);
                 break;
-            } else if(key == ConsoleKey.D3 || key == ConsoleKey.NumPad3)
+            }
+            else if (key == ConsoleKey.D3 || key == ConsoleKey.NumPad3)
             {
                 character = new Mage(name);
                 break;
-            } else
+            }
+            else
             {
                 continue;
             }
@@ -146,7 +149,7 @@ class Program
             Console.WriteLine("보유 중인 아이템을 관리할 수 있습니다.\n");
             UI.DrawLine();
 
-            switch (UI.SelectList(new List<string>(new string[] { "1.상태보기", "2.전투 시작(현재 진행 : "+ dungeon.floor + "층)", "3.인벤토리", "4.상점", "5.퀘스트", "6.저장" })))
+            switch (UI.SelectList(new List<string>(new string[] { "1.상태보기", "2.전투 시작(현재 진행 : " + dungeon.floor + "층)", "3.인벤토리", "4.상점", "5.퀘스트", "6.저장" })))
             {
                 case 0:
                     Status();
@@ -164,7 +167,7 @@ class Program
                 case 4:
                     Quest();
                     break;
-                case 5: 
+                case 5:
                     SaveGame();
                     break;
                 case -1:
@@ -322,10 +325,18 @@ class Program
 
         Shop shop = new Shop();
         shop.LoadOptions();
-
+        /*
         foreach (Item item in shop.items)
         {
             Console.WriteLine($"- {item.ToString()} | {item.price} G");
+        }
+        */
+        foreach (var item in shop.items)
+        {
+            if (!player.HasItem(item))
+            {
+                Console.WriteLine($"{item.ToString()} | {item.price} G");
+            }
         }
         Console.WriteLine("");
 
@@ -349,7 +360,7 @@ class Program
 
     static void BuyItem()
     {
-        while(true)
+        while (true)
         {
             Console.Clear();
             Console.ForegroundColor = ConsoleColor.Yellow;
@@ -361,6 +372,26 @@ class Program
 
             shop.LoadOptions();
 
+            // 플레이어가 구매할 수 있는 아이템 목록 생성
+            List<Item> purchasableItems = shop.items.Where(item => !player.HasItem(item)).ToList();
+            int selectedIndex = UI.SelectList(purchasableItems);
+
+            switch (UI.SelectList(new List<string>(new string[] { "- 아이템 구매" })))
+            {
+                case 0:
+                    if (selectedIndex >= 0 && selectedIndex < purchasableItems.Count)
+                    {
+                        Item selectedItem = purchasableItems[selectedIndex];
+                        int actualIndex = shop.items.IndexOf(selectedItem);
+                        shop.BuyItem(actualIndex, player);
+                        SaveGame();
+                    }
+                    break;
+                case -1:
+                    return;
+            }
+
+            /*
             int index = UI.SelectList(shop.items);
 
             switch (UI.SelectList(new List<string>(new string[] { "- 아이템 구매" })))
@@ -372,7 +403,8 @@ class Program
                 case -1:
                     return;
             }
-        } 
+            */
+        }
     }
 
     static void SellItem()
@@ -452,7 +484,7 @@ class Program
 
             if (questboard.quests[n].isActive && questboard.quests[n].isClear)
             {
-                switch (UI.SelectList(new List<string>(new string[] { "보상 받기"})))
+                switch (UI.SelectList(new List<string>(new string[] { "보상 받기" })))
                 {
                     case 0:
                         questboard.ReceiveReward(questboard.quests[n], player);

--- a/team6_TextGame/team6_TextGame/Shop.cs
+++ b/team6_TextGame/team6_TextGame/Shop.cs
@@ -25,7 +25,7 @@ namespace team6_TextGame
             {
                 player.gold -= items[index].price;
                 player.AddEquipsInven(items[index]);
-                items.RemoveAt(index);
+                //items.RemoveAt(index);
                 SaveOptions();
             }
         }
@@ -34,7 +34,7 @@ namespace team6_TextGame
         {
             Item item = player.equips[index];
             player.gold += (int)(item.price * 0.8);
-            AddItem(item);
+            //AddItem(item);
             player.equips.RemoveAt(index);
             SaveOptions();
         }


### PR DESCRIPTION
- 던전 보상으로 얻은 드랍 아이템 또한 상점에서 보이면 안되기 때문에 로직 수정

- 기존: 구매 아이템 상점 아이템 목록에서 제거 & 판매 시 추가

- 수정: 상점 아이템 리스트는 고정, 인벤토리와 목록 비교하여 가지고 있지 않은 아이템만 보여주